### PR TITLE
Matrix row/column sum/mean

### DIFF
--- a/src/matrix.js
+++ b/src/matrix.js
@@ -256,6 +256,50 @@ Sylvester.Matrix.prototype = {
     return m;
   },
 
+  sum: function(d) { // d is dimension, 0 means column sum and 1 means row sum
+    d = d || 0;
+    if (this.cols() === 0 || this.rows() === 0) { return null; }
+    switch (d) {
+      case 0:
+        return Sylvester.Vector.create(
+            this.elements.reduce(function (a, b) {
+              var i = a.length;
+              if (i === 0) return b.slice(0);
+
+              var ret = new Array(i);
+              while (i--) {
+                ret[i] = a[i] + b[i];
+              }
+              return ret;
+            }, []));
+      case 1:
+        var i = this.rows();
+        var els = new Array(i);
+        while (i--) {
+          els[i] = this.elements[i].reduce(
+              function (a, b) { return a + b; },
+              0);
+        }
+        return Sylvester.Vector.create(els);
+      default:
+        return null;
+    }
+  },
+
+  mean: function(d) { // d is the same as above
+    d = d || 0;
+    var rows = this.rows(), cols = this.cols();
+    if (cols === 0 || rows === 0) { return null; }
+    switch (d) {
+      case 0:
+        return this.sum(d).multiply(1.0 / rows);
+      case 1:
+        return this.sum(d).multiply(1.0 / cols);
+      default:
+        return null;
+    }
+  },
+
   indexOf: function(x) {
     if (this.elements.length === 0) { return null; }
     var index = null, ni = this.elements.length, i, nj = this.elements[0].length, j;

--- a/test/specs/matrix_spec.js
+++ b/test/specs/matrix_spec.js
@@ -334,4 +334,25 @@ JS.ENV.MatrixSpec = JS.Test.describe("Matrix", function() { with(this) {
       [0,0,0,7]
     ]))
   }})
+
+  test("sum", function() { with(this) {
+    var m = $M([
+      [1, 4, 2, 3],
+      [2, 1, 1, 3],
+      [5, 3, 2, 1],
+    ]);
+    assert(m.sum(0).eql([8, 8, 5, 7]));
+    assert(m.sum(1).eql([10, 7, 11]));
+  }})
+
+
+  test("mean", function() { with(this) {
+    var m = $M([
+      [1, 4, 2, 3],
+      [2, 1, 1, 3],
+      [5, 3, 2, 1],
+    ]);
+    assert(m.mean(0).eql([8/3, 8/3, 5/3, 7/3]));
+    assert(m.mean(1).eql([10/4, 7/4, 11/4]));
+  }})
 }})


### PR DESCRIPTION
Added some code for matrix {row, column} {sum, mean}.

M.sum(dim) returns the sum along dim (0 => sum rows, 1 => sum columns, default 0).
M.mean(dim) returns the mean along dim (same semantics as before).

If dim is not 0 or 1, null is returned. 

The return value of M.sum and M.mean are Vector objects.

Unit tests are included.
