### PR TITLE
Fix typo in docs link on home page

### DIFF
--- a/site/src/pages/index.haml
+++ b/site/src/pages/index.haml
@@ -35,7 +35,7 @@
   //   75 18 43</code></pre>
 
   <p style="clear: both">and any number of other useful arithmetic and geometric
-    operations. For more information, take a look at <a href="/docs">the API
+    operations. For more information, take a look at <a href="/docs.html">the API
     documentation</a>.</p>
 
   <a name="download"></a>


### PR DESCRIPTION
The front page body text currently links to "/docs" and 404s.
