### PR TITLE
Add pairwise ops.

### DIFF
--- a/site/src/pages/api/matrix.haml
+++ b/site/src/pages/api/matrix.haml
@@ -41,6 +41,7 @@
   <a href="#max"><code>max</code></a>,
   <a href="#minor"><code>minor</code></a>,
   <a href="#multiply"><code>multiply</code></a>,
+  <a href="#pairwisemultiply"><code>pairwiseMultiply</code></a>,
   <a href="#rank"><code>rank</code></a>,
   <a href="#rk"><code>rk</code></a>,
   <a href="#round"><code>round</code></a>,
@@ -376,6 +377,11 @@
     receiver with all its elements multiplied by <code>object</code>.</p>
 
   <p>This method is aliased as <a href="#x"><code>x</code></a>.</p>
+
+  <a name="pairwiseMultiply"></a>
+  <h3 class="method">pairwiseMultiply(<span class="arg">object</span>) <span class="version">future</span></h3>
+
+  <p>If <code>object</code> is a matrix of the same size as the receiver, then this method returns the result of multiplying each element in the receiver with the corresponding element in the object.</p>
 
   <a name="rank"></a>
   <h3 class="method">rank() <span class="version">0.1.0</span></h3>

--- a/site/src/pages/api/vector.haml
+++ b/site/src/pages/api/vector.haml
@@ -37,6 +37,8 @@
   <a href="#max"><code>max</code></a>,
   <a href="#modulus"><code>modulus</code></a>,
   <a href="#multiply"><code>multiply</code></a>,
+  <a href="#pairwiseDivide"><code>pairwiseDivide</code></a>,
+  <a href="#pairwiseMultiply"><code><pairwiseMultiply</code></a>,
   <a href="#reflectionin"><code>reflectionIn</code></a>,
   <a href="#rotate"><code>rotate</code></a>,
   <a href="#round"><code>round</code></a>,
@@ -267,6 +269,16 @@
   <p>Returns the vector obtained by multiplying all the elements of the receiver
     by the scalar quantity <code>k</code>. Aliased as
     <a href="#x"><code>x(k)</code></a>.</p>
+
+  <a name="pairwiseDivide"></a>
+  <h3 class="method">pairwiseDivide(<span class="arg">object</span>) <span class="version">future</span></h3>
+
+  <p>If <code>object</code> is a vector of the same size as the receiver, then this method returns the result of dividing each element in the receiver by the corresponding element in the object.</p>
+
+  <a name="pairwiseMultiply"></a>
+  <h3 class="method">pairwiseMultiply(<span class="arg">object</span>) <span class="version">future</span></h3>
+
+  <p>If <code>object</code> is a vector of the same size as the receiver, then this method returns the result of multiplying each element in the receiver with the corresponding element in the object.</p>
 
   <a name="reflectionin"></a>
   <h3 class="method">reflectionIn(<span class="arg">object</span>) <span class="version">0.1.0</span></h3>

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -213,6 +213,19 @@ Sylvester.Matrix.prototype = {
     return returnVector ? M.col(1) : M;
   },
 
+  pairwiseMultiply: function(matrix) {
+    if (!this.isSameSizeAs(matrix)) { return null; }
+    var els = [], i = this.elements.length, nj = this.elements[0].length, j;
+    while (i--) {
+      j = nj;
+      els[i] = [];
+      while (j--) {
+        els[i][j] = this.elements[i][j] * matrix.elements[i][j];
+      }
+    }
+    return Sylvester.Matrix.create(els);
+  },
+
   minor: function(a, b, c, d) {
     if (this.elements.length === 0) { return null; }
     var elements = [], ni = c, i, nj, j;

--- a/src/vector.js
+++ b/src/vector.js
@@ -116,6 +116,24 @@ Sylvester.Vector.prototype = {
     return this.map(function(x) { return x*k; });
   },
 
+  pairwiseMultiply: function(vector) {
+    if (!vector.elements || this.elements.length !== vector.elements.length) { return null; }
+    var els = [], te = this.elements, n = te.length, ve = vector.elements;
+    for (i = 0; i < n; i++) {
+      els[i] = te[i] * ve[i];
+    }
+    return Sylvester.Vector.create(els);
+  },
+
+  pairwiseDivide: function(vector) {
+    if (!vector.elements || this.elements.length !== vector.elements.length) { return null; }
+    var els = [], te = this.elements, n = te.length, ve = vector.elements;
+    for (i = 0; i < n; i++) {
+      els[i] = te[i] / ve[i];
+    }
+    return Sylvester.Vector.create(els);
+  },
+
   dot: function(vector) {
     var V = vector.elements || vector;
     var i, product = 0, n = this.elements.length;

--- a/test/specs/matrix_spec.js
+++ b/test/specs/matrix_spec.js
@@ -184,6 +184,13 @@ JS.ENV.MatrixSpec = JS.Test.describe("Matrix", function() { with(this) {
     assertNotNull( M1.x(M2.x(M1)) )
   }})
 
+  test("pairwiseMultiply", function() { with(this) {
+    var M1 = $M([[1,2],[3,4]]),
+      M2 = $M([[2,3],[4,5]]),
+      M3 = $M([[2,6],[12,20]]);
+    assert(M1.pairwiseMultiply(M2).eql(M3))
+  }})
+
   test("minor", function() { with(this) {
     var M2 = $M([
       [2,9],

--- a/test/specs/vector_spec.js
+++ b/test/specs/vector_spec.js
@@ -175,4 +175,19 @@ JS.ENV.VectorSpec = JS.Test.describe("Vector", function() { with(this) {
     assert( $V([12,1]).rotate(Math.PI/2, [5,1]).eql([5,8]) )
     assert( Vector.i.rotate(-Math.PI/2, Sylvester.Line.create([10, 0, 100], Vector.k)).eql([10,9,0]) )
   }})
+
+  test("pairwiseMultiply", function() { with(this) {
+    var V1 = $V([1,2,3]);
+    var V2 = $V([2,3,4]);
+    var V3 = $V([2,6,12]);
+    assert( V1.pairwiseMultiply(V2).eql(V3) );
+  }})
+
+  test("pairwiseDivide", function() { with(this) {
+    var V1 = $V([2,6,12]);
+    var V2 = $V([2,3,4]);
+    var V3 = $V([1,2,3]);
+    assert( V1.pairwiseDivide(V2).eql(V3) );
+  }})
+
 }})


### PR DESCRIPTION
Vector: pairwiseMultiply and pairwiseDivide. Matrix: pairwiseMultiply. In docs tagged as "Future".

Note that https://github.com/NaturalNode/node-sylvester has similar methods (albeit slightly slower implementations) with different names: elementMultiply, elementDivide. Wikipedia lists possible names as Hadamard product, Schur product, entrywise product (similar to pairwise) and googling seems more favorable for pairwise, but open to changing if we can sync code bases. (@chrisumbel)
