### PR TITLE
Optimizations

### DIFF
--- a/src/matrix.js
+++ b/src/matrix.js
@@ -271,7 +271,7 @@ Sylvester.Matrix.prototype = {
     if (!this.isSquare) { return null; }
     var els = [], n = this.elements.length;
     for (var i = 0; i < n; i++) {
-      els.push(this.elements[i][i]);
+      els[i] = this.elements[i][i];
     }
     return Sylvester.Vector.create(els);
   },

--- a/src/vector.js
+++ b/src/vector.js
@@ -8,13 +8,13 @@ var $V = Sylvester.Vector.create;
 
 Sylvester.Vector.Random = function(n) {
   var elements = [];
-  while (n--) { elements.push(Math.random()); }
+  while (n--) { elements[n] = Math.random(); }
   return Sylvester.Vector.create(elements);
 };
 
 Sylvester.Vector.Zero = function(n) {
   var elements = [];
-  while (n--) { elements.push(0); }
+  while (n--) { elements[n] = 0; }
   return Sylvester.Vector.create(elements);
 };
 
@@ -48,7 +48,7 @@ Sylvester.Vector.prototype = {
   map: function(fn, context) {
     var elements = [];
     this.each(function(x, i) {
-      elements.push(fn.call(context, x, i));
+      elements[i] = fn.call(context, x, i);
     });
     return Sylvester.Vector.create(elements);
   },
@@ -107,13 +107,18 @@ Sylvester.Vector.prototype = {
   },
 
   subtract: function(vector) {
-    var V = vector.elements || vector;
-    if (this.elements.length !== V.length) { return null; }
-    return this.map(function(x, i) { return x - V[i-1]; });
+    var V = vector.elements || vector,
+      m = this.elements.length;
+    if (m !== V.length) { return null; }
+    var te = this.elements, elements = [];
+    while (m--) { elements[m] = te[m] - V[m]; }
+    return Sylvester.Vector.create(elements);
   },
 
   multiply: function(k) {
-    return this.map(function(x) { return x*k; });
+    var te = this.elements, m = te.length, elements = [];
+    while (m--) { elements[m] = te[m] * k; }
+    return Sylvester.Vector.create(elements);
   },
 
   dot: function(vector) {
@@ -136,17 +141,17 @@ Sylvester.Vector.prototype = {
   },
 
   max: function() {
-    var m = 0, i = this.elements.length;
+    var m = 0, te = this.elements, i = te.length;
     while (i--) {
-      if (Math.abs(this.elements[i]) > Math.abs(m)) { m = this.elements[i]; }
+      if (Math.abs(te[i]) > Math.abs(m)) { m = te[i]; }
     }
     return m;
   },
 
   indexOf: function(x) {
-    var index = null, n = this.elements.length;
+    var index = null, te = this.elements, n = te.length;
     for (var i = 0; i < n; i++) {
-      if (index === null && this.elements[i] === x) {
+      if (index === null && te[i] === x) {
         index = i + 1;
       }
     }
@@ -158,13 +163,15 @@ Sylvester.Vector.prototype = {
   },
 
   round: function() {
-    return this.map(function(x) { return Math.round(x); });
+    var te = this.elements, m = te.length, elements = [];
+    while (m--) { elements[m] = Math.round(te[m]); }
+    return Sylvester.Vector.create(elements);
   },
 
   snapTo: function(x) {
-    return this.map(function(y) {
-      return (Math.abs(y - x) <= Sylvester.precision) ? x : y;
-    });
+    var te = this.elements, m = te.length, elements = [];
+    while (m--) { elements[m] = (Math.abs(te[m] - x) <= Sylvester.precision) ? x : te[m]; }
+    return Sylvester.Vector.create(elements);
   },
 
   distanceFrom: function(obj) {


### PR DESCRIPTION
Building arrays via `arr[i] = x` is ~45% faster than `arr.push(x)`. See http://jsperf.com/sylvesterloops/2
Store references to mOrV.elements.
Inline loops instead of call out to map, which calls to forEach.
